### PR TITLE
Avoid encoding binary with hex code directly (for py3)

### DIFF
--- a/gitBot.py
+++ b/gitBot.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import binascii
 import logging
 from datetime import datetime
 from config import CHATROOM_PRESENCE
@@ -30,7 +31,7 @@ class GitBot(BotPlugin):
             new_stuff = False
             for head in initial_state_dict:
                 if initial_state_dict[head] != new_state_dict[head]:
-                    logging.debug('%s: %s -> %s' % (head, initial_state_dict[head].encode("hex"), new_state_dict[head].encode("hex")))
+                    logging.debug('%s: %s -> %s' % (head, binascii.hexlify(initial_state_dict[head]), binascii.hexlify(new_state_dict[head])))
                     new_stuff = True
 
             if new_stuff:


### PR DESCRIPTION
1. [Python 3 disallows calling encode on bytes][1] resulting in: `AttributeError: 'bytes' object has no attribute 'encode'`
2. Use of `binascii` since "hex" codec is [dropped in some Py3 versions][2].

[1]: https://docs.python.org/3/howto/pyporting.html#text-versus-binary-data
[2]: http://stackoverflow.com/a/2340358/484127

P.S.: I know it's much digging for 2 line logging change, but I was curious